### PR TITLE
tinycc: fix broken install phase

### DIFF
--- a/tinycc/debian/rules
+++ b/tinycc/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 override_dh_auto_configure:
-	dh_auto_configure -- --tccdir=../tcc --docdir=/usr/share/doc/tcc
+	dh_auto_configure -- --tccdir=/usr/lib/tcc --docdir=/usr/share/doc/tcc
 ifeq (arm,$(DEB_HOST_ARCH_CPU))
 ifeq (armel,$(DEB_HOST_ARCH))
 	sed 's/\(TCC_ARM_VERSION\) .*/\1 4/' config.h

--- a/tinycc/debian/tcc.install
+++ b/tinycc/debian/tcc.install
@@ -1,2 +1,4 @@
 usr/bin
+usr/lib/tcc/include
+usr/lib/tcc/libtcc1.a
 usr/share


### PR DESCRIPTION
This fixes broken installation of libtcc and headers. We don't really using it, but better to fix it anyway.