### PR TITLE
mosquitto: add support openssl engine for private key storage.

### DIFF
--- a/mosquitto-1.4.15-1+wb7/client/pub_client.c
+++ b/mosquitto-1.4.15-1+wb7/client/pub_client.c
@@ -451,5 +451,6 @@ int main(int argc, char *argv[])
 	if(rc){
 		fprintf(stderr, "Error: %s\n", mosquitto_strerror(rc));
 	}
+	client_config_cleanup(&cfg);
 	return rc;
 }

--- a/mosquitto-1.4.15-1+wb7/client/sub_client.c
+++ b/mosquitto-1.4.15-1+wb7/client/sub_client.c
@@ -272,6 +272,7 @@ int main(int argc, char *argv[])
 	if(rc){
 		fprintf(stderr, "Error: %s\n", mosquitto_strerror(rc));
 	}
+	client_config_cleanup(&cfg);
 	return rc;
 }
 

--- a/mosquitto-1.4.15-1+wb7/lib/mosquitto.c
+++ b/mosquitto-1.4.15-1+wb7/lib/mosquitto.c
@@ -315,6 +315,7 @@ void _mosquitto_destroy(struct mosquitto *mosq)
 	if(mosq->tls_capath) _mosquitto_free(mosq->tls_capath);
 	if(mosq->tls_certfile) _mosquitto_free(mosq->tls_certfile);
 	if(mosq->tls_keyfile) _mosquitto_free(mosq->tls_keyfile);
+	if(mosq->tls_keyfile_engine) _mosquitto_free(mosq->tls_keyfile_engine);
 	if(mosq->tls_pw_callback) mosq->tls_pw_callback = NULL;
 	if(mosq->tls_version) _mosquitto_free(mosq->tls_version);
 	if(mosq->tls_ciphers) _mosquitto_free(mosq->tls_ciphers);
@@ -649,6 +650,7 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 {
 #ifdef WITH_TLS
 	FILE *fptr;
+	int rc;
 
 	if(!mosq || (!cafile && !capath) || (certfile && !keyfile) || (!certfile && keyfile)) return MOSQ_ERR_INVAL;
 
@@ -704,23 +706,26 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 	}
 
 	if(keyfile){
-		fptr = _mosquitto_fopen(keyfile, "rt", false);
-		if(fptr){
-			fclose(fptr);
-		}else{
-			if(mosq->tls_cafile){
-				_mosquitto_free(mosq->tls_cafile);
-				mosq->tls_cafile = NULL;
+		if (strlen(keyfile) < sizeof(KEYFILE_ENGINE_PREFIX) - 1 || strncmp(keyfile, KEYFILE_ENGINE_PREFIX, sizeof(KEYFILE_ENGINE_PREFIX) - 1)) {
+			mosq->tls_keyfile_engine = NULL;
+			fptr = _mosquitto_fopen(keyfile, "rt", false);
+			if(fptr){
+				fclose(fptr);
+			}else{
+				if(mosq->tls_cafile){
+					_mosquitto_free(mosq->tls_cafile);
+					mosq->tls_cafile = NULL;
+				}
+				if(mosq->tls_capath){
+					_mosquitto_free(mosq->tls_capath);
+					mosq->tls_capath = NULL;
+				}
+				if(mosq->tls_certfile){
+					_mosquitto_free(mosq->tls_certfile);
+					mosq->tls_certfile = NULL;
+				}
+				return MOSQ_ERR_INVAL;
 			}
-			if(mosq->tls_capath){
-				_mosquitto_free(mosq->tls_capath);
-				mosq->tls_capath = NULL;
-			}
-			if(mosq->tls_certfile){
-				_mosquitto_free(mosq->tls_certfile);
-				mosq->tls_certfile = NULL;
-			}
-			return MOSQ_ERR_INVAL;
 		}
 		mosq->tls_keyfile = _mosquitto_strdup(keyfile);
 		if(!mosq->tls_keyfile){
@@ -733,6 +738,22 @@ int mosquitto_tls_set(struct mosquitto *mosq, const char *cafile, const char *ca
 
 	mosq->tls_pw_callback = pw_callback;
 
+	rc = _mosquito_keyfile_engine_extract(mosq);
+	if (rc) {
+		if(mosq->tls_cafile){
+			_mosquitto_free(mosq->tls_cafile);
+			mosq->tls_cafile = NULL;
+		}
+		if(mosq->tls_capath){
+			_mosquitto_free(mosq->tls_capath);
+			mosq->tls_capath = NULL;
+		}
+		if(mosq->tls_certfile){
+			_mosquitto_free(mosq->tls_certfile);
+			mosq->tls_certfile = NULL;
+		}
+		return rc;
+}
 
 	return MOSQ_ERR_SUCCESS;
 #else

--- a/mosquitto-1.4.15-1+wb7/lib/mosquitto_internal.h
+++ b/mosquitto-1.4.15-1+wb7/lib/mosquitto_internal.h
@@ -180,6 +180,7 @@ struct mosquitto {
 	char *tls_capath;
 	char *tls_certfile;
 	char *tls_keyfile;
+	char *tls_keyfile_engine;
 	int (*tls_pw_callback)(char *buf, int size, int rwflag, void *userdata);
 	char *tls_version;
 	char *tls_ciphers;

--- a/mosquitto-1.4.15-1+wb7/lib/net_mosq.c
+++ b/mosquitto-1.4.15-1+wb7/lib/net_mosq.c
@@ -102,6 +102,7 @@ void _mosquitto_net_init(void)
 #endif
 
 #ifdef WITH_TLS
+	OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL);
 	SSL_load_error_strings();
 	SSL_library_init();
 	OpenSSL_add_all_algorithms();
@@ -211,6 +212,7 @@ int _mosquitto_socket_close(struct mosquitto *mosq)
 #endif
 {
 	int rc = 0;
+	struct mosquitto *context;
 
 	assert(mosq);
 #ifdef WITH_TLS
@@ -242,7 +244,9 @@ int _mosquitto_socket_close(struct mosquitto *mosq)
 	{
 		if((int)mosq->sock >= 0){
 #ifdef WITH_BROKER
-			HASH_DELETE(hh_sock, db->contexts_by_sock, mosq);
+			HASH_FIND(hh_sock, db->contexts_by_sock, &mosq->sock, sizeof(context->sock), context);
+			if (context != NULL)
+				HASH_DELETE(hh_sock, db->contexts_by_sock, mosq);
 #endif
 			rc = COMPAT_CLOSE(mosq->sock);
 			mosq->sock = INVALID_SOCKET;
@@ -494,6 +498,31 @@ int mosquitto__socket_connect_tls(struct mosquitto *mosq)
 }
 #endif
 
+#ifdef WITH_TLS
+int _mosquito_keyfile_engine_extract(struct mosquitto *mosq)
+{
+	char *keyfile, *p;
+
+	if (mosq->tls_keyfile == NULL)
+		return MOSQ_ERR_SUCCESS;
+
+	if (strlen(mosq->tls_keyfile) < sizeof(KEYFILE_ENGINE_PREFIX) - 1 || strncmp(mosq->tls_keyfile, KEYFILE_ENGINE_PREFIX, sizeof(KEYFILE_ENGINE_PREFIX) - 1))
+		return MOSQ_ERR_SUCCESS;
+
+	keyfile = mosq->tls_keyfile;
+
+	keyfile += sizeof(KEYFILE_ENGINE_PREFIX) - 1;
+	p = strchr(keyfile, ':');
+	if (!p)
+		return MOSQ_ERR_INVAL;
+	*p = '\0';
+	mosq->tls_keyfile_engine = _mosquitto_strdup(keyfile);
+	*p++ = ':';
+	mosq->tls_keyfile = _mosquitto_strdup(p);
+	return MOSQ_ERR_SUCCESS;
+}
+#endif
+
 int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, uint16_t port, const char *bind_address, bool blocking)
 {
 #ifdef WITH_TLS
@@ -594,21 +623,47 @@ int _mosquitto_socket_connect_step3(struct mosquitto *mosq, const char *host, ui
 				}
 			}
 			if(mosq->tls_keyfile){
-				ret = SSL_CTX_use_PrivateKey_file(mosq->ssl_ctx, mosq->tls_keyfile, SSL_FILETYPE_PEM);
-				if(ret != 1){
+				if (mosq->tls_keyfile_engine) {
+					ENGINE *engine = ENGINE_by_id(mosq->tls_keyfile_engine);
+					if (engine == NULL) {
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: failed ENGINE_by_id.");
+						COMPAT_CLOSE(mosq->sock);
+						return MOSQ_ERR_TLS;
+					}
+					EVP_PKEY *pkey = ENGINE_load_private_key(engine, mosq->tls_keyfile, 0, 0);
+					if (pkey == NULL) {
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: failed ENGINE_load_private_key.");
+						COMPAT_CLOSE(mosq->sock);
+						ENGINE_free(engine);
+						return MOSQ_ERR_TLS;
+					}
+					ENGINE_free(engine);
+
+					if (SSL_CTX_use_PrivateKey(mosq->ssl_ctx, pkey) == 0) {
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: failed SSL_CTX_use_PrivateKey.");
+						COMPAT_CLOSE(mosq->sock);
+						EVP_PKEY_free(pkey);
+						return MOSQ_ERR_TLS;
+					}
+					
+					EVP_PKEY_free(pkey);
+				} else {
+					ret = SSL_CTX_use_PrivateKey_file(mosq->ssl_ctx, mosq->tls_keyfile, SSL_FILETYPE_PEM);
+					if(ret != 1){
 #ifdef WITH_BROKER
-					_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Unable to load client key file, check bridge_keyfile \"%s\".", mosq->tls_keyfile);
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Unable to load client key file, check bridge_keyfile \"%s\".", mosq->tls_keyfile);
 #else
-					_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Unable to load client key file \"%s\".", mosq->tls_keyfile);
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Unable to load client key file \"%s\".", mosq->tls_keyfile);
 #endif
-					COMPAT_CLOSE(mosq->sock);
-					return MOSQ_ERR_TLS;
-				}
-				ret = SSL_CTX_check_private_key(mosq->ssl_ctx);
-				if(ret != 1){
-					_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Client certificate/key are inconsistent.");
-					COMPAT_CLOSE(mosq->sock);
-					return MOSQ_ERR_TLS;
+						COMPAT_CLOSE(mosq->sock);
+						return MOSQ_ERR_TLS;
+					}
+					ret = SSL_CTX_check_private_key(mosq->ssl_ctx);
+					if(ret != 1){
+						_mosquitto_log_printf(mosq, MOSQ_LOG_ERR, "Error: Client certificate/key are inconsistent.");
+						COMPAT_CLOSE(mosq->sock);
+						return MOSQ_ERR_TLS;
+					}
 				}
 			}
 #ifdef REAL_WITH_TLS_PSK

--- a/mosquitto-1.4.15-1+wb7/lib/net_mosq.h
+++ b/mosquitto-1.4.15-1+wb7/lib/net_mosq.h
@@ -90,6 +90,7 @@ int _mosquitto_packet_read(struct mosquitto *mosq);
 #ifdef WITH_TLS
 int _mosquitto_socket_apply_tls(struct mosquitto *mosq);
 int mosquitto__socket_connect_tls(struct mosquitto *mosq);
+int _mosquito_keyfile_engine_extract(struct mosquitto *mosq);
 #endif
 
 #endif

--- a/mosquitto-1.4.15-1+wb7/lib/tls_mosq.h
+++ b/mosquitto-1.4.15-1+wb7/lib/tls_mosq.h
@@ -34,6 +34,8 @@ Contributors:
 #  endif
 #endif
 
+#define KEYFILE_ENGINE_PREFIX  "engine:"
+
 int _mosquitto_server_certificate_verify(int preverify_ok, X509_STORE_CTX *ctx);
 int _mosquitto_verify_certificate_hostname(X509 *cert, const char *hostname);
 

--- a/mosquitto-1.4.15-1+wb7/src/bridge.c
+++ b/mosquitto-1.4.15-1+wb7/src/bridge.c
@@ -49,6 +49,7 @@ int mqtt3_bridge_new(struct mosquitto_db *db, struct _mqtt3_bridge *bridge)
 	char hostname[256];
 	int len;
 	char *id, *local_id;
+	int rc;
 
 	assert(db);
 	assert(bridge);
@@ -110,9 +111,15 @@ int mqtt3_bridge_new(struct mosquitto_db *db, struct _mqtt3_bridge *bridge)
 	new_context->tls_capath = new_context->bridge->tls_capath;
 	new_context->tls_certfile = new_context->bridge->tls_certfile;
 	new_context->tls_keyfile = new_context->bridge->tls_keyfile;
+	new_context->tls_keyfile_engine = new_context->bridge->tls_keyfile_engine;
 	new_context->tls_cert_reqs = SSL_VERIFY_PEER;
 	new_context->tls_version = new_context->bridge->tls_version;
 	new_context->tls_insecure = new_context->bridge->tls_insecure;
+	rc = _mosquito_keyfile_engine_extract(new_context);
+	if (rc) {
+		_mosquitto_free(local_id);
+		return rc;
+	}
 #ifdef REAL_WITH_TLS_PSK
 	new_context->tls_psk_identity = new_context->bridge->tls_psk_identity;
 	new_context->tls_psk = new_context->bridge->tls_psk;

--- a/mosquitto-1.4.15-1+wb7/src/mosquitto_broker.h
+++ b/mosquitto-1.4.15-1+wb7/src/mosquitto_broker.h
@@ -335,6 +335,7 @@ struct _mqtt3_bridge{
 	char *tls_capath;
 	char *tls_certfile;
 	char *tls_keyfile;
+	char *tls_keyfile_engine;
 	bool tls_insecure;
 	char *tls_version;
 #  ifdef REAL_WITH_TLS_PSK


### PR DESCRIPTION
Enable use openssl engine for private key storage.
Example conf:

bridge_cafile   /etc/mosquitto/certs/ca.crt
bridge_certfile /etc/mosquitto/certs/client_host.crt
bridge_keyfile  engine:ateccx08:ATECCx08:00:04:C0:00

mosquitto_pub -h myhost.net --cert client_host.crt --key 'engine:ateccx08:ATECCx08:00:04:C0:00' --cafile ca.crt -t "test" -m "message" -p 3332