### PR TITLE
40540-bugfix Fixed appearance of dead.letter in /root directory

### DIFF
--- a/mosquitto-1.4.15-1+wb7/debian/changelog
+++ b/mosquitto-1.4.15-1+wb7/debian/changelog
@@ -1,3 +1,9 @@
+mosquitto (1.4.15-1+wb7-5) stable; urgency=medium
+
+  * Fixed appearance of dead.letter in /root directory
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 28 Dec 2021 12:21:00 +0300
+
 mosquitto (1.4.15-1+wb7-4) stable; urgency=medium
 
   * Add support openssl engine for private key storage

--- a/mosquitto-1.4.15-1+wb7/debian/mosquitto.logrotate
+++ b/mosquitto-1.4.15-1+wb7/debian/mosquitto.logrotate
@@ -2,6 +2,7 @@
 	rotate 7
 	daily
 	compress
+	delaycompress
 	size 100k
 	nocreate
 	missingok


### PR DESCRIPTION
Поправил настройки, чтобы через некоторое время  в директории /root не появлялся файл dead.letter.